### PR TITLE
fix  Missing carla_autoware_bridge.converter Package Issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ package_name = 'carla_autoware_bridge'
 setup(
     name=package_name,
     version='0.2.0',
-    packages=[package_name],
+    packages=[package_name, 'carla_autoware_bridge.converter'],
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),


### PR DESCRIPTION
The converter package within the carla_autoware_bridge is not being included after building with colcon.